### PR TITLE
ref: replace task substitution system

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,9 +239,6 @@ Additionally, it has all the methods of the [Taskable](#taskable) interface.
 // Create a new task within the taskable.
 $taskable->createTask(string $taskName): Task;
 
-// Remove the last task from the taskable and add another in its place.
-$taskable->replaceLastTask(Task $task): void;
-
 $taskable->getTasks(): array;
 
 $taskable->getLastTask(): ?Task;

--- a/src/Concerns/HasTasks.php
+++ b/src/Concerns/HasTasks.php
@@ -22,13 +22,6 @@ trait HasTasks
         return $task;
     }
 
-    public function replaceLastTask(Task $task): void
-    {
-        array_pop($this->tasks);
-
-        $this->tasks[] = $task;
-    }
-
     /**
      * @return array<Task>
      */

--- a/src/Contracts/Taskable.php
+++ b/src/Contracts/Taskable.php
@@ -10,8 +10,6 @@ interface Taskable
 {
     public function createTask(string $taskName): Task;
 
-    public function replaceLastTask(Task $task): void;
-
     /**
      * @return array<Task>
      */

--- a/src/Services/TimeWardenManager.php
+++ b/src/Services/TimeWardenManager.php
@@ -75,10 +75,9 @@ final class TimeWardenManager implements Taskable
         /** @var Task|null $lastTask */
         $lastTask = $taskable->getLastTask();
 
-        // If the last task was never started, we overwrite it
+        // If the last task was never started, we replace its name with `$taskName`
         if ($lastTask instanceof Task && ! $lastTask->hasStarted()) {
-            $taskable->replaceLastTask(new Task($taskName, $taskable));
-
+            $lastTask->name = $taskName;
         } else {
             // If there is a task, but it has already started, we stop it
             if ($lastTask instanceof Task && $lastTask->hasStarted()) {

--- a/src/Support/Facades/TimeWarden.php
+++ b/src/Support/Facades/TimeWarden.php
@@ -19,7 +19,6 @@ use Tomloprod\TimeWarden\Task;
  *
  * Taskable methods:
  * @method static Task createTask(string $taskName)
- * @method static void replaceLastTask(Task $task)
  * @method static array<Task> getTasks(string $taskName)
  * @method static Task|null getLastTask()
  * @method static float getDuration()

--- a/tests/Contracts/TaskableTest.php
+++ b/tests/Contracts/TaskableTest.php
@@ -20,20 +20,6 @@ it('can add a task', function (): void {
         ->toContain($task);
 });
 
-it('can replace the last task', function (): void {
-    $task1 = $this->tasksClass->createTask('TaskName1');
-
-    $task2 = new Task('TaskName2', $this->tasksClass);
-
-    $this->tasksClass->replaceLastTask($task2);
-
-    expect($this->tasksClass->getTasks())
-        ->not->toContain($task1);
-
-    expect($this->tasksClass->getTasks())
-        ->toContain($task2);
-});
-
 it('can retrieve the last task', function (): void {
     $task1 = $this->tasksClass->createTask('TaskName1');
     $task2 = $this->tasksClass->createTask('TaskName2');

--- a/tests/Contracts/TaskableTest.php
+++ b/tests/Contracts/TaskableTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Tomloprod\TimeWarden\Concerns\HasTasks;
 use Tomloprod\TimeWarden\Contracts\Taskable;
-use Tomloprod\TimeWarden\Task;
 
 beforeEach(function (): void {
     $this->tasksClass = new class implements Taskable

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Tomloprod\TimeWarden\Group;
-use Tomloprod\TimeWarden\Task;
 
 it('can be created with a name', function (): void {
     $group = new Group('GroupName');

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -20,19 +20,6 @@ it('can add a task', function (): void {
     expect($task->getTaskable())->toBe($group);
 });
 
-it('can replace the last task', function (): void {
-    $group = new Group('GroupName');
-
-    $task1 = $group->createTask('TaskName1');
-    $task2 = new Task('TaskName2', $group);
-
-    $group->replaceLastTask($task2);
-
-    expect($group->getTasks())->not->toContain($task1);
-
-    expect($group->getTasks())->toContain($task2);
-});
-
 it('can start the last task if it exists', function (): void {
     $group = new Group('GroupName');
     $task = $group->createTask('TaskName');


### PR DESCRIPTION
Delete the `replaceLastTask` method and simply change the name of the last empty task when creating a new one.