### PR TITLE
feat(Group): Rename existing group if it has no tasks during new group creation

### DIFF
--- a/src/Services/TimeWardenManager.php
+++ b/src/Services/TimeWardenManager.php
@@ -24,9 +24,7 @@ final class TimeWardenManager implements Taskable
      */
     private array $groups = [];
 
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 
     public function __clone()
     {
@@ -61,8 +59,12 @@ final class TimeWardenManager implements Taskable
     {
         $this->stop();
 
-        /** @todo do the same as task(). overwrite empty groups, avoid groups with same name (in this case... active group with name?) */
-        $this->groups[] = new Group($groupName);
+        $group = $this->getLastGroup();
+        if ($group && ! $group->getLastTask()) {
+            $group->name = $groupName;
+        } else {
+            $this->groups[] = new Group($groupName);
+        }
 
         return self::$instance;
     }

--- a/src/Services/TimeWardenManager.php
+++ b/src/Services/TimeWardenManager.php
@@ -24,7 +24,9 @@ final class TimeWardenManager implements Taskable
      */
     private array $groups = [];
 
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 
     public function __clone()
     {
@@ -60,7 +62,7 @@ final class TimeWardenManager implements Taskable
         $this->stop();
 
         $group = $this->getLastGroup();
-        if ($group && ! $group->getLastTask()) {
+        if ($group && ! $group->getLastTask() instanceof Task) {
             $group->name = $groupName;
         } else {
             $this->groups[] = new Group($groupName);

--- a/tests/Services/TimeWardenManagerTest.php
+++ b/tests/Services/TimeWardenManagerTest.php
@@ -50,16 +50,32 @@ it('resets the singleton instance', function (): void {
 it('can create and retrieve groups', function (): void {
     $instance = TimeWardenManager::instance();
 
+    $instance->group('Group1')->task('foo');
+    $instance->group('Group2')->task('bar');
+
+    $groups = $instance->getGroups();
+
+    expect($groups)->toHaveCount(2);
+
+    expect($groups[0])->toBeInstanceOf(Group::class);
+    expect($groups[1])->toBeInstanceOf(Group::class);
+
+    expect($groups[0]->name)->toBe('Group1');
+    expect($groups[1]->name)->toBe('Group2');
+});
+
+it('overwrite last group if doesn\'t have tasks when a new group is created', function (): void {
+    $instance = TimeWardenManager::instance();
+
     $instance->group('Group1');
     $instance->group('Group2');
+    $instance->group('Group3');
 
     $groups = $instance->getGroups();
 
     expect($groups)->toHaveCount(1);
-
+    expect($groups[0]->name)->toBe('Group3');
     expect($groups[0])->toBeInstanceOf(Group::class);
-
-    expect($groups[0]->name)->toBe('Group2');
 });
 
 it('can create tasks of timewarden instance', function (): void {

--- a/tests/Services/TimeWardenManagerTest.php
+++ b/tests/Services/TimeWardenManagerTest.php
@@ -55,13 +55,11 @@ it('can create and retrieve groups', function (): void {
 
     $groups = $instance->getGroups();
 
-    expect($groups)->toHaveCount(2);
+    expect($groups)->toHaveCount(1);
 
     expect($groups[0])->toBeInstanceOf(Group::class);
 
-    expect($groups[0]->name)->toBe('Group1');
-
-    expect($groups[1]->name)->toBe('Group2');
+    expect($groups[0]->name)->toBe('Group2');
 });
 
 it('can create tasks of timewarden instance', function (): void {


### PR DESCRIPTION
If the previous group has no tasks, rename the existing group with the new group name instead of creating a new group. This ensures efficient reuse of group names.